### PR TITLE
Support missing ATAC or RNA from a sequencing run

### DIFF
--- a/shareseq.smk
+++ b/shareseq.smk
@@ -71,14 +71,21 @@ barcode_chunks = [
     f"barcodes_{i:02d}" for i in range(1, len(end_barcode_groups) + 1)
 ]
 
-outputs = (
-    ["ATAC/alignment_stats.json", "ATAC/barcode_stats.json"] +
-    ["RNA/alignment_stats.json", "RNA/barcode_stats.json"] +
-    expand('ATAC/{sample}.fragments.tsv.gz', sample=config["samples"].keys()) +
-    expand('RNA/{sample}.{file}.gz', sample=config["samples"].keys(), file=["matrix.mtx", "barcodes.tsv", "features.tsv"]) +
-    expand('{sequencing_path}/fragments.tsv.gz', sequencing_path=utils.get_sequencing_paths("ATAC", config)) +
-    expand('{sequencing_path}/{file}.gz', sequencing_path=utils.get_sequencing_paths("RNA", config), file=["matrix.mtx", "barcodes.tsv", "features.tsv"])
-)
+outputs = []
+if len(utils.get_sequencing_paths("ATAC", config)) > 0:
+    outputs += (
+        ["ATAC/alignment_stats.json", "ATAC/barcode_stats.json"] +
+        expand('ATAC/{sample}.fragments.tsv.gz', sample=config["samples"].keys()) +
+        expand('{sequencing_path}/fragments.tsv.gz', sequencing_path=utils.get_sequencing_paths("ATAC", config))
+    )
+
+if len(utils.get_sequencing_paths("RNA", config)) > 0:
+    outputs += (
+        ["RNA/alignment_stats.json", "RNA/barcode_stats.json"] +
+        expand('RNA/{sample}.{file}.gz', sample=config["samples"].keys(), file=["matrix.mtx", "barcodes.tsv", "features.tsv"]) +
+        expand('{sequencing_path}/{file}.gz', sequencing_path=utils.get_sequencing_paths("RNA", config), file=["matrix.mtx", "barcodes.tsv", "features.tsv"])
+    )
+
 filtered_outputs = []
 for o in outputs:
     if os.path.exists(o):

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,8 @@ def get_sequencing_paths(assay, config, run_types=["bcl"]):
     for run_id, run in config["sequencing"].items():
         assert run["type"] in ["bcl"]
         if run["type"] == "bcl" and "bcl" in run_types:
+            if f"{assay}_I2" not in run:
+                raise Exception(f"Barcodes for '{assay}_I2' not found in config for run '{run_id}'. Please add line '{assay}_I2: {{}}' if the assay type is unused")
             sequencing_paths += [
                 f"{assay}/{run_id}/{sublib_id}" for sublib_id in run[f"{assay}_I2"]
             ]


### PR DESCRIPTION
To help avoid errors, this still requires both keys ATAC_I2 and RNA_I2
be present, but it will print an error message explaining the correct
syntax for no samples in an assay.