### PR TITLE
fix automatically masked short reads by bcl2fastq

### DIFF
--- a/scripts/prep_fastq/run_bcl2fastq.py
+++ b/scripts/prep_fastq/run_bcl2fastq.py
@@ -50,6 +50,7 @@ def main():
     parser.add_argument("--threads", type=int, default=4, help="Number of threads to use")
     parser.add_argument("--num_tile_chunks", type=int, default=1, help="Number of chunks to split the tiles into")
     parser.add_argument("--tile_chunk", type=int, default=1, help="Which tile chunk to extract (1-based index)")
+    parser.add_argument("--short_mask", type=int, default=0, help="See bcl2fastq documentation option --mask-short-adapter-reads")
 
     args = parser.parse_args()
 
@@ -92,6 +93,7 @@ def main():
         "--no-lane-splitting",
         "--create-fastq-for-index-reads",
         "--use-bases-mask", get_bases_mask(args.input),
+        "--mask-short-adapter-reads", str(args.short_mask),
         "--output", args.output,
         "--processing-threads", str(args.threads), # Empirically, vast majority of the work is spent in processing threads, so we don't add threads for other purposes
         "--tiles", ",".join(tiles),


### PR DESCRIPTION
Eyal just showed me his processed data from last time, where all the read 2 are Ns (read 2 is only 10 bp in length to capture UMIs). When he mentioned the issue a couple weeks back, I didnt realize that he only sequenced 10bp for R2 so didn't catch this issue earlier.

The NNNNNNNNNN is caused by bcl2fastq automatically filtering out short adapter reads with a read length less than 22 (22 is the default value for flag `--mask-short-adapter-reads`) (see page 14 of [bcl2fastq doc](https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2-v2-20-software-guide-15051736-03.pdf)). I've added an optional argument in `scripts/prep_fastq/run_bcl2fastq.py` that sets `--mask-short-adapter-reads` to zero. 

After rerun, Eyal has UMIs now!