### PR TITLE
Fix plotting org

### DIFF
--- a/scripts/plotting/plot_overview.R
+++ b/scripts/plotting/plot_overview.R
@@ -75,8 +75,8 @@ plot_rna_alignment_stats <- function(input_path, output_path){
     return()
   }
   else{
-    rna.align.stats.list <- list.files(paste0(input_path,"/RNA"), pattern="alignment_stats.json", recursive=T)
-    rna.align.stats.data <- lapply(paste0(input_path,"/RNA/",rna.align.stats.list),function(f){fromJSON(file=f) %>% as.data.frame()}) %>% do.call(rbind, .) %>% t()
+    rna.align.stats.list <- list.files(paste0(input_path,"/RNA/sublibraries"), pattern="alignment_stats.json", recursive=T)
+    rna.align.stats.data <- lapply(paste0(input_path,"/RNA/sublibraries/",rna.align.stats.list),function(f){fromJSON(file=f) %>% as.data.frame()}) %>% do.call(rbind, .) %>% t()
     
     rna.name.list <- unlist(strsplit(paste0("RNA/",rna.align.stats.list), "/alignment_stats.json"))
     rna.name.list <- gsub("/", "_", rna.name.list)
@@ -118,8 +118,8 @@ plot_atac_alignment_stats <- function(input_path, output_path){
     return()
   }
   else{
-    atac.align.stats.list <- list.files(paste0(input_path,"/ATAC"), pattern="alignment_stats.json", recursive=T)
-    atac.align.stats.data <- lapply(paste0(input_path,"/ATAC/",atac.align.stats.list),function(f){fromJSON(file=f) %>% as.data.frame()}) %>% do.call(rbind, .) %>% t()
+    atac.align.stats.list <- list.files(paste0(input_path,"/ATAC/sublibraries"), pattern="alignment_stats.json", recursive=T)
+    atac.align.stats.data <- lapply(paste0(input_path,"/ATAC/sublibraries/",atac.align.stats.list),function(f){fromJSON(file=f) %>% as.data.frame()}) %>% do.call(rbind, .) %>% t()
     
     atac.name.list <- unlist(strsplit(paste0("ATAC/",atac.align.stats.list), "/alignment_stats.json"))
     atac.name.list <- gsub("/", "_", atac.name.list)
@@ -170,10 +170,14 @@ plot_total_reads <- function(rna.align.stats.data, atac.align.stats.data, output
 
 
 ########## main ############
-bc.stats.list <- list.files(input_path, pattern="barcode_stats.json", recursive=T)
-bc.stats.data <-sapply(paste0(input_path,"/",bc.stats.list),function(f){fromJSON(file=f)})
-name.list <- unlist(strsplit(bc.stats.list, "/barcode_stats.json"))
-name.list <- gsub("/", "_", name.list)
+bc.stats.list <- Sys.glob(file.path(input_path, "*/sublibraries/*/barcode_stats.json"))
+bc.stats.data <- sapply(bc.stats.list,function(f){fromJSON(file=f)})
+get.sublib.name <- function (f){
+  basenames <- strsplit(f, "/")[[1]] %>% tail(4)
+  return(paste0(basenames[1], "_", basenames[3]))
+}
+
+name.list <- lapply(bc.stats.list, get.sublib.name) %>% unlist
 colnames(bc.stats.data) <- name.list
 
 if (!dir.exists(output_path)){

--- a/scripts/plotting/plot_rna.R
+++ b/scripts/plotting/plot_rna.R
@@ -5,6 +5,7 @@ suppressPackageStartupMessages({
   library(patchwork)
   library(ggrastr)
   library(gridExtra)
+  library(BPCells)
 })
 
 
@@ -20,25 +21,40 @@ stopifnot(dir.exists(paste0(input_path, "/RNA")))
 stopifnot(flag_saveobj %in% c("T","F"))
 
 ########## functions ############
-read_data <- function(input_path){
-  sample.list <- list.files(paste0(input_path,"/RNA"), pattern=".matrix.mtx.gz", recursive=F) %>% 
-    strsplit(".matrix.mtx.gz") %>% unlist
-  
-  prefix <- paste0(input_path,"/RNA/")
-  mtx.suffix <- "matrix.mtx.gz"
-  cells.suffix <- "barcodes.tsv.gz"
-  features.suffix <- "features.tsv.gz"
+read_data <- function(input.dir, use.sublib=FALSE, min.umi=100){
+  # read the matrix market files output from https://github.com/GreenleafLab/shareseq-pipeline 
+  # input.dir: output folder from the preprocessing pipeline 
+  # use.sublib: if true, read from RNA/sublibraries instead of RNA/samples
+  # min.umi: filter out cell barcodes with less than min.umi reads
+ 
+  if (use.sublib){
+    sample.list <- list.files(file.path(input.dir,"/RNA/sublibraries/"), pattern="matrix.mtx.gz", recursive=T) %>% 
+      strsplit("/matrix.mtx.gz") %>% unlist
+    
+    prefix <- file.path(input.dir,"/RNA/sublibraries/")
+    mtx.suffix <- "/matrix.mtx.gz"
+    cells.suffix <- "/barcodes.tsv.gz"
+    features.suffix <- "/features.tsv.gz"
+  } else{
+    sample.list <- list.files(file.path(input.dir,"/RNA/samples/"), pattern=".matrix.mtx.gz", recursive=F) %>% 
+      strsplit(".matrix.mtx.gz") %>% unlist
+    
+    prefix <- file.path(input.dir,"/RNA/samples/")
+    mtx.suffix <- ".matrix.mtx.gz"
+    cells.suffix <- ".barcodes.tsv.gz"
+    features.suffix <- ".features.tsv.gz"
+  }
   
   data.list <- lapply(sample.list, function(n){
-    ReadMtx(mtx=paste0(prefix, n, ".", mtx.suffix),
-            cells=paste0(prefix, n, ".", cells.suffix),
-            features=paste0(prefix, n, ".", features.suffix))
+    ReadMtx(mtx=paste0(prefix, n,  mtx.suffix),
+            cells=paste0(prefix, n, cells.suffix),
+            features=paste0(prefix, n, features.suffix))
   })
   
   names(data.list) <- sample.list
   
   obj.list <- lapply(sample.list,function(n){
-    CreateSeuratObject(counts=data.list[[n]], project=n, min.cells=3, min.features=100)
+    CreateSeuratObject(counts=data.list[[n]], project=n, min.cells=0, min.features=min.umi)
   })
   
   
@@ -60,22 +76,19 @@ read_data <- function(input_path){
 }
 
 
-plot_knee_all <- function(proj, output_path){
+plot_knee_all <- function(proj, output_path, umi.cutoff=1000, gene.cutoff=500){
   # overview stats for all cells from all samples
-  g1 <- ggplot(proj@meta.data[order(proj$nCount_RNA,decreasing = TRUE),]) + aes(x=1:dim(proj)[2],y=nCount_RNA) + 
-    rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-    xlab("ranked cell barcodes") + ylab("UMI counts") + ggtitle("UMI counts vs cell barcodes") +
-    theme(plot.title = element_text(hjust = 0.5))
+  g1 <- plot_read_count_knee(proj$nCount_RNA, cutoff = umi.cutoff) + 
+    ggtitle("nUMI vs cell barcodes, all") + ylab("nUMI") + geom_point(color="darkblue")
+  g2 <- plot_read_count_knee(proj$nFeature_RNA, cutoff = gene.cutoff) + 
+    ggtitle("nGene vs cell barcodes, all") + ylab("nGene") + geom_point(color="darkblue")
   
-  g2 <- ggplot(proj@meta.data[order(proj$nFeature_RNA,decreasing = TRUE),]) + aes(x=1:dim(proj)[2],y=nFeature_RNA) + 
-    rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-    xlab("ranked cell barcodes") + ylab("gene counts") + ggtitle("Gene counts vs cell barcodes") +
-    theme(plot.title = element_text(hjust = 0.5))
-  
-  g3_base <- ggplot(proj@meta.data[order(proj$nCount_RNA,decreasing = TRUE),]) + aes(x=nCount_RNA,y=nFeature_RNA) + 
-    rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + 
-    xlab("UMI counts") + ylab("gene counts") + ggtitle("Detected gene counts vs UMI counts") +
-    theme(plot.title = element_text(hjust = 0.5))
+  downsample.idx <- plot_read_count_knee(proj$nCount_RNA, return_data=TRUE)
+  g3_base <- ggplot(proj@meta.data[names(downsample.idx$data$reads),]) + aes(x=nCount_RNA,y=nFeature_RNA) + 
+    geom_point(colour="darkblue") + theme_classic() + 
+    xlab("nUMI") + ylab("nGene") + ggtitle("nGene vs nUMI, all") + 
+    geom_vline(xintercept=umi.cutoff, linetype="dashed") + geom_hline(yintercept=gene.cutoff, linetype="dashed") +
+    scale_x_log10() + scale_y_log10() + annotation_logticks(sides="bl") 
   
   cell_count_text_a <- paste(paste0("Number of Cells that detected > 0 UMIs:       ",sum(proj$nCount_RNA > 0)), 
                              paste0("Number of Cells that detected > 10 UMIs:     ",sum(proj$nCount_RNA > 10)),
@@ -98,42 +111,34 @@ plot_knee_all <- function(proj, output_path){
 }
 
 
-plot_knee_sublib <- function(proj, output_path){
+plot_knee_sublib <- function(proj, output_path, umi.cutoff=1000, gene.cutoff=500){
   # UMI and gene knee plots for each sublibrary
   sublib.list <- unique(proj$sublib)
   
   pdf(paste0(output_path, "/rna_kneeplots_persublib.pdf"),width=10,height=5)
   for (sample in sublib.list){
     subproj <- proj@meta.data[proj$sublib == sample,]
-    g1 <- ggplot(subproj[order(subproj$nCount_RNA,decreasing = TRUE),]) + aes(x=1:dim(subproj)[1],y=nCount_RNA) + 
-      rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-      xlab("ranked cell barcodes") + ylab("UMI counts") + ggtitle(paste0("UMI counts vs cell barcodes, ", sample)) +
-      theme(plot.title = element_text(hjust = 0.5))
-    g2 <- ggplot(subproj[order(subproj$nFeature_RNA,decreasing = TRUE),]) + aes(x=1:dim(subproj)[1],y=nFeature_RNA) + 
-      rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-      xlab("ranked cell barcodes") + ylab("gene counts") + ggtitle(paste0("Gene counts vs cell barcodes, ", sample)) +
-      theme(plot.title = element_text(hjust = 0.5))
+    g1 <- plot_read_count_knee(subproj$nCount_RNA, cutoff = umi.cutoff) + 
+      ggtitle(paste0("nUMI vs cell barcodes, ", sample)) + ylab("nUMI") + geom_point(color="darkblue")
+    g2 <- plot_read_count_knee(subproj$nFeature_RNA, cutoff = gene.cutoff) + 
+      ggtitle(paste0("nGene vs cell barcodes, ", sample)) + ylab("nGene") + geom_point(color="darkblue")
     print(g1+g2)
   }
   invisible(dev.off())
 }
 
 
-plot_knee_sample <- function(proj, output_path){
+plot_knee_sample <- function(proj, output_path, umi.cutoff=1000, gene.cutoff=500){
   # UMI and gene knee plots for each sample
   sample.list <- unique(proj$sample)
   
   pdf(paste0(output_path, "/rna_kneeplots_persample.pdf"),width=10,height=5)
   for (sample in sample.list){
     subproj <- proj@meta.data[proj$sample == sample,]
-    g1 <- ggplot(subproj[order(subproj$nCount_RNA,decreasing = TRUE),]) + aes(x=1:dim(subproj)[1],y=nCount_RNA) + 
-      rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-      xlab("ranked cell barcodes") + ylab("UMI counts") + ggtitle(paste0("UMI counts vs cell barcodes, ", sample)) +
-      theme(plot.title = element_text(hjust = 0.5))
-    g2 <- ggplot(subproj[order(subproj$nFeature_RNA,decreasing = TRUE),]) + aes(x=1:dim(subproj)[1],y=nFeature_RNA) + 
-      rasterise(geom_point(colour="darkblue"),dpi=300) + theme_classic() + scale_x_log10() + scale_y_log10() +
-      xlab("ranked cell barcodes") + ylab("gene counts") + ggtitle(paste0("Gene counts vs cell barcodes, ", sample)) +
-      theme(plot.title = element_text(hjust = 0.5))
+    g1 <- plot_read_count_knee(subproj$nCount_RNA, cutoff = umi.cutoff) + 
+      ggtitle(paste0("nUMI vs cell barcodes, ", sample)) + ylab("nUMI") + geom_point(color="darkblue")
+    g2 <- plot_read_count_knee(subproj$nFeature_RNA, cutoff = gene.cutoff) + 
+      ggtitle(paste0("nGene vs cell barcodes, ", sample)) + ylab("nGene") + geom_point(color="darkblue")
     print(g1+g2)
   }
   invisible(dev.off())
@@ -150,7 +155,7 @@ plot_violin_umi_gene <- function(proj, output_path){
 
 
 plot_umap <- function(proj, output_path){
-  proj <- SCTransform(proj, vst.flavor = "v2") %>% RunPCA %>% FindNeighbors(dims = 1:50) %>%
+  proj <- NormalizeData(proj) %>% FindVariableFeatures(nfeatures=2000) %>% ScaleData %>% RunPCA %>% FindNeighbors(dims = 1:50) %>%
     FindClusters(resolution = 0.2) %>% RunUMAP(dims = 1:50)
   
   p <- DimPlot(proj, group.by="seurat_clusters") +  DimPlot(proj, group.by="sample") +
@@ -201,15 +206,20 @@ plot_cluster_composition <- function(proj, output_path){
 
 
 ########## main ############
+message("reading data")
 proj <- read_data(input_path)
+#proj <- read_data(input_path, use.sublib=T) # use this if only want sublibrary level qc, no sample info
 
 if (flag_saveobj == "T"){
+  message("saving raw object")
   saveRDS(proj, file=paste0(output_path, "/RNA_proj_raw.rds"))
 }
 
 if (!dir.exists(output_path)){
   dir.create(output_path, recursive = TRUE, showWarnings = FALSE)
 }
+
+message("plotting knee plots")
 plot_knee_all(proj, output_path)
 plot_knee_sublib(proj, output_path)
 plot_knee_sample(proj, output_path)
@@ -218,9 +228,12 @@ plot_knee_sample(proj, output_path)
 proj <- proj[,(proj$nCount_RNA>1000) & (proj$nFeature_RNA>500) & (proj$percent.mt<30)]
 
 plot_violin_umi_gene(proj, output_path)
+
+message("plotting umap")
 proj <- plot_umap(proj, output_path)
 plot_cluster_composition(proj, output_path)
 
 if (flag_saveobj == "T"){
+  message("saving clustered object")
   saveRDS(proj, file=paste0(output_path, "/RNA_proj_clustered.rds"))
 }

--- a/scripts/plotting/plot_rna.R
+++ b/scripts/plotting/plot_rna.R
@@ -67,9 +67,15 @@ read_data <- function(input.dir, use.sublib=FALSE, min.umi=100){
   
   # adding a few attributes
   proj$sublib <- proj$orig.ident
-  tmp <- strsplit(rownames(proj@meta.data), paste0("_",proj$orig.ident,"_"))
-  proj$sample <- unlist(lapply(tmp, function(n){n[1]}))
-  proj$cb <- unlist(lapply(tmp, function(n){n[2]}))
+  if (use.lib){
+    tmp <- strsplit(rownames(proj@meta.data), "_")
+    proj$sample <- unlist(lapply(tmp, function(n){n[1]}))
+    proj$cb <- unlist(lapply(tmp, function(n){n[2]}))
+  } else{
+    tmp <- strsplit(rownames(proj@meta.data), paste0("_",proj$orig.ident,"_"))
+    proj$sample <- unlist(lapply(tmp, function(n){n[1]}))
+    proj$cb <- unlist(lapply(tmp, function(n){n[2]}))
+  }
   mito_gene_id <- rownames(proj)[grepl("^MT-", rownames(proj))]
   proj$percent.mt <- PercentageFeatureSet(proj, features=mito_gene_id)
   return(proj)

--- a/scripts/plotting/plot_rna.R
+++ b/scripts/plotting/plot_rna.R
@@ -67,7 +67,7 @@ read_data <- function(input.dir, use.sublib=FALSE, min.umi=100){
   
   # adding a few attributes
   proj$sublib <- proj$orig.ident
-  if (use.lib){
+  if (use.sublib){
     tmp <- strsplit(rownames(proj@meta.data), "_")
     proj$sample <- unlist(lapply(tmp, function(n){n[1]}))
     proj$cb <- unlist(lapply(tmp, function(n){n[2]}))


### PR DESCRIPTION
- fixed the plotting scripts to read from the correct locations after the reorganization of output folders from the last PR #13 
- added support in plot_atac.R and plot_rna.R for reading data per sample or per sublibrary in the plotting script, addressing the need to only plot based on per sublibrary outputs (e.g. a qc run with sublibraries across different experiments, where sample outputs were not generated). This is not an argument yet, as I don't expect it to be a common use case for others (for now)
- added Rscript runtime messages 
- changed knee plots functions to use the faster BPCells knee plot function with downsampling