### PR TITLE
Container

### DIFF
--- a/plot.sh
+++ b/plot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-smk_output=$(grep 'output_dir:' $1 | cut -d: -f2 | cut -d\" -f2)
+smk_output=$(grep -v ^\# $1 | grep 'output_dir:' | cut -d: -f2 | cut -d\" -f2)
 
 # overview
 Rscript scripts/plotting/plot_overview.R $smk_output plots/overview/

--- a/prep_fastq.smk
+++ b/prep_fastq.smk
@@ -8,6 +8,11 @@ import utils
 
 workdir: config["output_dir"]
 
+# global singularity container to use
+# only set if container given in config and is not none
+if "singularity" in config.keys() and config["singularity"]: 
+    singularity: config["singularity"]
+
 wildcard_constraints:
     sequencing_path = "(ATAC|RNA)/([^/]+/)?[^/]+", # Sequencing path is 2-3 folders
     tile_chunk = "[0-9]+"

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# If container given in config, run in container mode
 # Keep all temporary files for now
-snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile $1 --notemp
-
-snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile $1 --notemp
+if [ ! -z "$(grep -v ^\# $1 | grep -e 'singularity:' | cut -d' ' -f2)" ]
+then
+    container=$(grep -v ^\# $1 | grep -e 'singularity:' | cut -d' ' -f2)
+    echo "Running in singularity container: $container"
+    snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile $1 --notemp --use-singularity
+    snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile $1 --notemp --use-singularity 
+else
+    echo "Running in local mode"
+    snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile $1 --notemp
+    snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile $1 --notemp
+fi

--- a/runs/share_novaseq_b1.yaml
+++ b/runs/share_novaseq_b1.yaml
@@ -1,17 +1,22 @@
-output_dir: "/scratch/users/bparks/shareseq/share_novaseq_b1"
+output_dir: "/path/to/output/folder/"
 
 ## Uncomment these lines to do a trial run with only two small test chunks per sublibrary
 # chunk_size: 2_000_000
 # test_chunks: 2
 chunk_size: 20_000_000
 
+## Check the genomes
+# importantly, make sure the STAR index is compatible with your STAR version
 genome:
-  bowtie2: /oak/stanford/groups/wjg/share/uPrep/genomes/hg38/indexes/bowtie2/hg38
-  star: /oak/stanford/groups/wjg/share/genomes/star/GRCh38.p7/
-  gene_annotation: /oak/stanford/groups/wjg/bliu/resources/gtf/gencode.v41.annotation.BPfiltered.gtf
+  bowtie2: /oak/stanford/groups/wjg/bliu/resources/shareseq_references/hg38/bowtie2/hg38
+  star: /oak/stanford/groups/wjg/bliu/resources/shareseq_references/hg38/star # this is for STAR 2.7+ 
+  gene_annotation: /oak/stanford/groups/wjg/bliu/resources/shareseq_references/hg38/gencode.v41.annotation.filtered.gtf
 
-# Regular expressions for 1st round barcodes that should be mapped to each sample
-# Must cover all 1st round barcodes 
+## Uncomment the line below to run in a container
+# singularity: "/oak/stanford/groups/wjg/bliu/containers/shareseq_latest.sif"
+
+## Regular expressions for 1st round barcodes that should be mapped to each sample
+# Must cover all 1st round barcodes, can use resources like regex101.com to check syntax 
 # (use a dummy Undetermined sample if some 1st round barcodes are unused)
 samples:
   sample1_b1:  "A[0-9][0-9]"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,95 @@
+FROM eddelbuettel/r2u:focal
+
+# install R packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        time \
+        libxml2-dev \
+        libssl-dev \
+        libcurl4-openssl-dev \
+        libgsl-dev \
+        libhdf5-dev && \
+    install.r Seurat tidyverse patchwork ggrastr rjson gridExtra && \
+    install.r BiocManager remotes && \
+    installGithub.r mojaveazure/seurat-disk
+
+#RUN ln -s /usr/local/lib/R/site-library/littler/examples/installBioc.r /usr/local/bin/ && \
+#    installBioc.r BSgenome.Hsapiens.UCSC.hg38
+RUN ln -s /usr/local/lib/R/site-library/littler/examples/installBioc.r /usr/bin/ && \
+    installBioc.r BSgenome.Hsapiens.UCSC.hg38
+
+
+RUN install.r devtools hdf5r RSpectra && \
+    MAKEFLAGS="-j 4" r -e 'devtools::install_github(c("bnprks/BPCells")); quit(status=!requireNamespace("BPCells"))'
+
+
+# install miniconda 
+RUN apt-get update -q && \
+    apt-get install -q -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        git \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        mercurial \
+        openssh-client \
+        procps \
+        subversion \
+        wget \
+        zstd \
+        gawk \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH /opt/conda/bin:$PATH
+
+CMD [ "/bin/bash" ]
+
+# Leave these args here to better use the Docker build cache
+ARG CONDA_VERSION=py310_22.11.1-1
+
+RUN set -x && \
+    UNAME_M="$(uname -m)" && \
+    if [ "${UNAME_M}" = "x86_64" ]; then \
+        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
+        SHA256SUM="00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6"; \
+    elif [ "${UNAME_M}" = "s390x" ]; then \
+        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
+        SHA256SUM="a150511e7fd19d07b770f278fb5dd2df4bc24a8f55f06d6274774f209a36c766"; \
+    elif [ "${UNAME_M}" = "aarch64" ]; then \
+        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
+        SHA256SUM="48a96df9ff56f7421b6dd7f9f71d548023847ba918c3826059918c08326c2017"; \
+    elif [ "${UNAME_M}" = "ppc64le" ]; then \
+        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh"; \
+        SHA256SUM="4c86c3383bb27b44f7059336c3a46c34922df42824577b93eadecefbf7423836"; \
+    fi && \
+    wget "${MINICONDA_URL}" -O miniconda.sh -q && \
+    echo "${SHA256SUM} miniconda.sh" > shasum && \
+    if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
+    mkdir -p /opt && \
+    bash miniconda.sh -b -p /opt/conda && \
+    rm miniconda.sh shasum && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+    /opt/conda/bin/conda clean -afy
+
+# ensure at least 4GB RAM when building the container
+RUN conda install -c dranew bcl2fastq
+RUN conda install -c conda-forge poppler 
+RUN conda install -c bioconda -c conda-forge snakemake
+RUN conda install -c bioconda -c conda-forge bowtie2 fastp subread star umi_tools pysam samtools htslib 
+
+# fix a samtools dependency issue by reinstalling ncurses
+RUN conda install -c conda-forge ncurses
+
+RUN install.r Cairo && \
+    r -e 'BiocManager::install("TFBSTools", type="source")' && \
+    installGithub.r GreenleafLab/chromVAR GreenleafLab/chromVARmotifs && \
+    r -e 'devtools::install_github("GreenleafLab/ArchR", ref="master", repos = BiocManager::repositories(), \
+          dependency=TRUE, type="source")' && \
+    r -e 'library(ArchR); ArchR::installExtraPackages()'

--- a/scripts/plotting/plot_rna.R
+++ b/scripts/plotting/plot_rna.R
@@ -153,9 +153,9 @@ plot_knee_sample <- function(proj, output_path, umi.cutoff=1000, gene.cutoff=500
 
 plot_violin_umi_gene <- function(proj, output_path){
   median_tbl <- proj@meta.data %>% group_by(sublib) %>% 
-        summarise(median_umi=median(nCount_RNA), median_gene=median(nFeature_RNA))
-  p1 <- VlnPlot(proj, features = c("nCount_RNA","nFeature_RNA","percent.mt"), pt.size=0, group.by="sublib")
-  p <- p1 + tableGrob(median_tbl, rows = NULL)
+        summarise(median_umi=median(nCount_RNA), median_gene=median(nFeature_RNA), cells_passfilter=n())
+  p1 <- VlnPlot(proj, features = c("nCount_RNA","nFeature_RNA","percent.mt"), pt.size=0, group.by="sublib", log=T)
+  p <- p1 / tableGrob(median_tbl, rows = NULL)
   ggsave(plot=p, file=paste0(output_path,"/rna_umi_gene_violin.pdf"), dpi=300, width=10, height=8)
 }
 

--- a/scripts/shareseq/stats_collect_rna.py
+++ b/scripts/shareseq/stats_collect_rna.py
@@ -102,14 +102,7 @@ star_log_template = r"""Number of input reads \|	(?P<total_reads>\d+)
         Number of reads mapped to multiple loci \|	(?P<total_multimap>\d+)
              % of reads mapped to multiple loci \|	{percentage_regex}
         Number of reads mapped to too many loci \|	(?P<total_multimap_toomany>\d+)
-             % of reads mapped to too many loci \|	{percentage_regex}
-                                  UNMAPPED READS:
-       % of reads unmapped: too many mismatches \|	{percentage_regex}
-                 % of reads unmapped: too short \|	{percentage_regex}
-                     % of reads unmapped: other \|	{percentage_regex}
-                                  CHIMERIC READS:
-                       Number of chimeric reads \|	\d+
-                            % of chimeric reads \|	{percentage_regex}""".format(percentage_regex=percentage_regex)
+             % of reads mapped to too many loci \|	{percentage_regex}""".format(percentage_regex=percentage_regex)
 
 def parse_star_log(path):
     output_groups = ["total_reads", "unique_map_reads", "total_multimap", "total_multimap_toomany",]

--- a/shareseq.smk
+++ b/shareseq.smk
@@ -14,6 +14,11 @@ import utils
 
 workdir: config["output_dir"]
 
+# global singularity container to use
+# only set if container given in config and is not none
+if "singularity" in config.keys() and config["singularity"]: 
+    singularity: config["singularity"] 
+    
 #############################
 ### Config parsing and metadata helpers
 #############################
@@ -391,7 +396,6 @@ rule rna_star:
            " --alignSJoverhangMin 8 "
            " --alignSJDBoverhangMin 1 " 
            " --sjdbScore 1 "          
-           " --limitIObufferSize 400000000 "
            " --limitOutSJcollapsed 5000000 "
         
 # Add genome annotation


### PR DESCRIPTION
- I've tried to do a fully containerized version (where even snakemake is called from within the container) but I think it gets too hacky trying to call slurm from within the container, so the user still needs to have singularity and snakemake preinstalled, but everything else can be run from within the container
- enabling the container mode simply by add a line in run config file
- changed the rule `rna_star` and script `scripts/shareseq/stats_collect_rna.py` to be compatible with both STAR 2.5.4b (the default version on sherlock) and STAR 2.7.10b (version in container)
- updated README to include instructions on how to use the container
- updated the plotting instruction to submit as a batch job with a good amount of memory (still Seurat v4)
- minor enhancements of plotting based on user feedback