### PR TITLE
removed the manual filtering of outputs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Snakemake-based pipeline for processing SHARE-seq data
    ``` 
 6. (optional) To delete the intermediate outputs after a run, run the following:
    ```bash
-   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
-   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-output --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-output --config filter_dag=false
    ```
    Note that this step is not needed if you remove all the `--notemp` flags from `run.sh` before running step 3. 
    Snakemake will delete the intermediate outputs by default as it runs without the `--notemp` flag.
@@ -108,8 +108,8 @@ Snakemake-based pipeline for processing SHARE-seq data
    ```
 7. (optional) To delete the intermediate outputs after a run, run the following:
    ```bash
-   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
-   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-output --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-output --config filter_dag=false
    ```
    Note that this step is not needed if you remove all the `--notemp` flags from `run.sh` before running step 3.
    Snakemake will delete the intermediate outputs by default as it runs without the `--notemp` flag.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ Snakemake-based pipeline for processing SHARE-seq data
    ```bash
    sbatch -p wjg,sfgf,biochem --mem-per-cpu=64g plot.sh runs/MY_CONFIG_FILE.yaml
    ``` 
-
+6. (optional) To delete the intermediate outputs after a run, run the following:
+   ```bash
+   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   ```
+   Note that this step is not needed if you remove all the `--notemp` flags from `run.sh` before running step 3. 
+   Snakemake will delete the intermediate outputs by default as it runs without the `--notemp` flag.
+   
 ## Running on Sherlock with container
 
 0. Install `singularity` and `snakemake` 
@@ -99,6 +106,13 @@ Snakemake-based pipeline for processing SHARE-seq data
    ```bash
    sbatch -p wjg,sfgf,biochem --mem-per-cpu=64g --job-name=plot --wrap "singularity exec --cleanenv /YOUR/CONTAINERS/DIR/shareseq_latest.sif ./plot.sh runs/MY_CONFIG_FILE.yaml"
    ```
+7. (optional) To delete the intermediate outputs after a run, run the following:
+   ```bash
+   snakemake --profile=$(pwd)/profile -s prep_fastq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   snakemake --profile=$(pwd)/profile -s shareseq.smk --configfile runs/MY_CONFIG_FILE.yaml --delete-temp-out --config filter_dag=false
+   ```
+   Note that this step is not needed if you remove all the `--notemp` flags from `run.sh` before running step 3.
+   Snakemake will delete the intermediate outputs by default as it runs without the `--notemp` flag.
 
 ---
 

--- a/prep_fastq.smk
+++ b/prep_fastq.smk
@@ -23,18 +23,11 @@ outputs = (
     expand("{sequencing_path}/read_count.txt", sequencing_path=utils.get_sequencing_paths("ATAC", config) + utils.get_sequencing_paths("RNA", config)) + 
     expand("bcl2fastq/{sequencing_path}_{read}.fastq.zst", sequencing_path=utils.get_sequencing_paths("ATAC", config, run_types=["bcl"]) + utils.get_sequencing_paths("RNA", config, run_types="bcl"), read=["R1", "R2"])
 )
-filtered_outputs = []
-for o in outputs:
-    if os.path.exists(o):
-        print(f"Skipping existing output: {o}", file=sys.stderr)
-    else:
-        filtered_outputs.append(o)
-
 
 
 localrules: all
 rule all:
-    input: filtered_outputs
+    input: outputs
         
 
 #############################

--- a/prep_fastq.smk
+++ b/prep_fastq.smk
@@ -24,10 +24,19 @@ outputs = (
     expand("bcl2fastq/{sequencing_path}_{read}.fastq.zst", sequencing_path=utils.get_sequencing_paths("ATAC", config, run_types=["bcl"]) + utils.get_sequencing_paths("RNA", config, run_types="bcl"), read=["R1", "R2"])
 )
 
+if "filter_dag" in config.keys() and config["filter_dag"]=="false":
+    filtered_outputs = outputs
+else:
+    filtered_outputs = []
+    for o in outputs:
+        if os.path.exists(o):
+            print(f"Skipping existing output: {o}", file=sys.stderr)
+        else:
+            filtered_outputs.append(o)
 
 localrules: all
 rule all:
-    input: outputs
+    input: filtered_outputs
         
 
 #############################

--- a/shareseq.smk
+++ b/shareseq.smk
@@ -98,15 +98,8 @@ if len(utils.get_sequencing_paths("RNA", config)) > 0:
         expand('RNA/sublibraries/{sublibrary}/{file}.gz', sublibrary=utils.get_sublibraries("RNA", config), file=["matrix.mtx", "barcodes.tsv", "features.tsv"])
     )
 
-filtered_outputs = []
-for o in outputs:
-    if os.path.exists(o):
-        print(f"Skipping existing output: {o}", file=sys.stderr)
-    else:
-        filtered_outputs.append(o)
-
 rule all:
-    input: filtered_outputs 
+    input: outputs 
 
 #############################
 ### Build C-based scripts

--- a/shareseq.smk
+++ b/shareseq.smk
@@ -98,8 +98,18 @@ if len(utils.get_sequencing_paths("RNA", config)) > 0:
         expand('RNA/sublibraries/{sublibrary}/{file}.gz', sublibrary=utils.get_sublibraries("RNA", config), file=["matrix.mtx", "barcodes.tsv", "features.tsv"])
     )
 
+if "filter_dag" in config.keys() and config["filter_dag"]=="false":
+    filtered_outputs = outputs
+else:
+    filtered_outputs = []
+    for o in outputs:
+        if os.path.exists(o):
+            print(f"Skipping existing output: {o}", file=sys.stderr)
+        else:
+            filtered_outputs.append(o)
+
 rule all:
-    input: outputs 
+    input: filtered_outputs 
 
 #############################
 ### Build C-based scripts


### PR DESCRIPTION
I received feedback from our beta test user (the one and only EMR!) that his output folder is 5TB for a nova seq run and he'd like to delete the temporary files after running the pipeline with the `--notemp` option. Snakemake has the builtin `--delete-tmp-output` option that you can use to do this, but with the manual filtering of outputs we currently have, snakemake skips everything as a whole and does not register the temporary files for deletion.

A bit of a design choice dilemma here, I can't tell which one is better: 
- do we want to preserve the speed of snakemake building DAG (which can probably be improved by more computing power without rule filtering, but one can argue instead of deleting temp output, you can just move the `samples` and `sublibraries` folder elsewhere)? 
- or do we want to enable the `--delete-tmp-output` function for a cleaner data management workflow but potentially sacrificing the speed of building DAG after an interrupted run?