### PR TITLE
Fix bug in calculating +4/-4 Tn5 offset

### DIFF
--- a/scripts/shareseq/bam_to_fragments.py
+++ b/scripts/shareseq/bam_to_fragments.py
@@ -24,7 +24,7 @@ while True:
 
     chromosome = read.reference_name
     start = prev_read.reference_start + 4
-    end = start + prev_read.template_length - 4
+    end = prev_read.reference_start + prev_read.template_length - 4
     cell_barcode = read.get_tag("CB")
     print(chromosome, start, end, cell_barcode, sep="\t")
     prev_read = next(input, None)


### PR DESCRIPTION
As pointed out by Eyal/Surag, this calculation actually applies a +4/0 correction due to not keeping track of the fact that the start coordinate had already been adjusted.