### PR TITLE
Added brackets around sample barcode regex

### DIFF
--- a/shareseq.smk
+++ b/shareseq.smk
@@ -280,7 +280,7 @@ rule atac_split_samples:
     output:
         fragments = temp('ATAC/sublibraries/{sublibrary}/{sample}.tsv.zst'),
     params:
-        barcode_pattern = lambda w: f"\t{config['samples'][w.sample]}\\+",
+        barcode_pattern = lambda w: f"\t({config['samples'][w.sample]})\\+",
         sublibrary_id = lambda w: w.sublibrary
     threads: 4
     shell: "zstd -dc {input.fragments} | "
@@ -540,7 +540,7 @@ rule rna_unique_cells_sample:
     output:
         cells = 'RNA/samples/{sample}.barcodes.tsv.gz'
     params:
-        barcode_pattern = lambda w: f"_{config['samples'][w.sample]}\\+"
+        barcode_pattern = lambda w: f"_({config['samples'][w.sample]})\\+"
     shell: "gzip -dc {input.cells} | "
            "grep -E '{params.barcode_pattern}' | "
            "sort --unique | gzip > {output.cells}"
@@ -573,7 +573,7 @@ rule rna_mtx_chunk_sample:
         script = srcdir("scripts/shareseq/mtx_from_counts.py"),
         memory = "4G",
         sublibrary_id = lambda w: w.sublibrary,
-        barcode_pattern = lambda w: f"\t{config['samples'][w.sample]}\\+"
+        barcode_pattern = lambda w: f"\t({config['samples'][w.sample]})\\+"
     threads: 4
     shell: "zstd -dc {input.counts} | "
            "grep -E '{params.barcode_pattern}' | " # Filter to sample


### PR DESCRIPTION
For more complicated sample barcode regex other than the simple "A[0-9][0-9]" format, brackets are necessary for defining the correct barcode pattern

E.g. For a counts_dedup.tsv.zst file that looks like this
```
ENSG00000000003.15	A06+E06+F12	1
ENSG00000000003.15	A09+E08+C12	1
ENSG00000000003.15	B01+H05+B12	1
ENSG00000000003.15	B02+D09+D12	1
ENSG00000000003.15	B10+C04+A12	1
ENSG00000000003.15	C05+D03+A12	1
ENSG00000000003.15	C09+G05+F12	1
ENSG00000000003.15	D04+E11+A12	1
ENSG00000000003.15	E10+F08+E12	1
ENSG00000000003.15	E11+B06+H12	1
```
If the sample comes from either column 9 or 11 on the first round barcoding plate, without brackets `grep -P '\t[A-H]09|[A-H]11\+'` would be incorrect:
```
ENSG00000000003.15	A09+E08+C12	1
ENSG00000000003.15	C09+G05+F12	1
ENSG00000000003.15	D04+E11+A12	1
ENSG00000000003.15	E11+B06+H12	1
```
And with brackets `grep -P '\t([A-H]09|[A-H]11)\+'` it's correct:
```
ENSG00000000003.15	A09+E08+C12	1
ENSG00000000003.15	C09+G05+F12	1
ENSG00000000003.15	E11+B06+H12	1
```